### PR TITLE
Use CMAKE_POSITION_INDEPENDENT_CODE to force fPIC option (previously …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+
 language: c
 
 before_install:
@@ -12,6 +14,9 @@ before_install:
   - sudo make install
   - sudo ldconfig
   - cd -
+  - sudo add-apt-repository ppa:kubuntu-ppa/backports -y
+  - sudo apt-get update
+  - sudo apt-get install --only-upgrade cmake
 
 script:
   - mkdir _build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.9)
 
 project(energymon)
 set(PROJECT_VERSION 0.1.0)
@@ -12,25 +12,18 @@ set(PKG_CONFIG_LIBDIR "\${prefix}/lib")
 set(PKG_CONFIG_INCLUDEDIR "\${prefix}/include/energymon")
 set(PKG_CONFIG_CFLAGS "-I\${includedir}")
 
+# force fPIC on static libs
+set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+
 include_directories(${PROJECT_SOURCE_DIR}/inc)
 include_directories(${PROJECT_SOURCE_DIR}/src)
-
-macro(SET_FPIC target)
-  # Required to force fPIC on static libs
-  # 'set (CMAKE_POSITION_INDEPENDENT_CODE TRUE)' not supported until cmake 2.8.9
-  IF(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-    SET_TARGET_PROPERTIES(${target} PROPERTIES COMPILE_FLAGS "-fPIC")
-  ENDIF(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-endmacro(SET_FPIC)
 
 macro(BUILD_DEFAULT source deplibs definitions)
   add_library(energymon-default SHARED ${source})
   target_link_libraries(energymon-default ${deplibs})
-  SET_FPIC(energymon-default)
 
   add_library(energymon-default-static STATIC ${source})
   target_link_libraries(energymon-default-static ${deplibs})
-  SET_FPIC(energymon-default-static)
 
   set_target_properties(energymon-default energymon-default-static PROPERTIES COMPILE_DEFINITIONS "ENERGYMON_DEFAULT;${definitions}")
 endmacro(BUILD_DEFAULT)

--- a/dummy/CMakeLists.txt
+++ b/dummy/CMakeLists.txt
@@ -5,10 +5,7 @@ set(DESCRIPTION "Dummy EnergyMon implementation")
 # Libraries
 
 add_library(${LNAME} SHARED ${SOURCES})
-SET_FPIC(${LNAME})
-
 add_library(${LNAME}-static STATIC ${SOURCES})
-SET_FPIC(${LNAME}-static)
 
 if(DEFAULT STREQUAL "dummy")
   BUILD_DEFAULT("${SOURCES}" "" "")

--- a/msr/CMakeLists.txt
+++ b/msr/CMakeLists.txt
@@ -6,11 +6,9 @@ set(DESCRIPTION "EnergyMon implementation for Intel Model Specific Register")
 
 add_library(${LNAME} SHARED ${SOURCES})
 target_link_libraries(${LNAME} m)
-SET_FPIC(${LNAME})
 
 add_library(${LNAME}-static STATIC ${SOURCES})
 target_link_libraries(${LNAME}-static m)
-SET_FPIC(${LNAME}-static)
 
 if(DEFAULT STREQUAL "msr")
   BUILD_DEFAULT("${SOURCES}" "m" "")

--- a/odroid/CMakeLists.txt
+++ b/odroid/CMakeLists.txt
@@ -6,11 +6,9 @@ set(DESCRIPTION "EnergyMon implementation for ODROID systems")
 
 add_library(${LNAME} SHARED ${SOURCES})
 target_link_libraries(${LNAME} pthread)
-SET_FPIC(${LNAME})
 
 add_library(${LNAME}-static STATIC ${SOURCES})
 target_link_libraries(${LNAME}-static pthread)
-SET_FPIC(${LNAME}-static)
 
 if(DEFAULT STREQUAL "odroid")
   BUILD_DEFAULT("${SOURCES}" "pthread" "")

--- a/osp/CMakeLists.txt
+++ b/osp/CMakeLists.txt
@@ -16,19 +16,15 @@ endif(NOT ${HIDAPIUSB_FOUND})
 
 add_library(${LNAME} SHARED ${SOURCES})
 target_link_libraries(${LNAME} hidapi-libusb)
-SET_FPIC(${LNAME})
 
 add_library(${LNAME}-static STATIC ${SOURCES})
 target_link_libraries(${LNAME}-static hidapi-libusb)
-SET_FPIC(${LNAME}-static)
 
 add_library(${LNAME}-polling SHARED ${SOURCES})
 target_link_libraries(${LNAME}-polling hidapi-libusb pthread)
-SET_FPIC(${LNAME}-polling)
 
 add_library(${LNAME}-polling-static STATIC ${SOURCES})
 target_link_libraries(${LNAME}-polling-static hidapi-libusb pthread)
-SET_FPIC(${LNAME}-polling-static)
 
 if(DEFAULT STREQUAL "osp")
   BUILD_DEFAULT("${SOURCES}" "hidapi-libusb" "")

--- a/rapl/CMakeLists.txt
+++ b/rapl/CMakeLists.txt
@@ -5,10 +5,7 @@ set(DESCRIPTION "EnergyMon implementation for Intel RAPL")
 # Libraries
 
 add_library(${LNAME} SHARED ${SOURCES})
-SET_FPIC(${LNAME})
-
 add_library(${LNAME}-static STATIC ${SOURCES})
-SET_FPIC(${LNAME}-static)
 
 if(DEFAULT STREQUAL "rapl")
   BUILD_DEFAULT("${SOURCES}" "" "")


### PR DESCRIPTION
…forced for x86_64 only, now needed for ARM).

Update CMake dependency to 2.8.9 to support this change.
Update travis config to fetch required CMake version