### PR TITLE
Use -Wextra -pedantic -pedantic-errors -std=gnu99

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.8.9)
 project(energymon)
 set(PROJECT_VERSION 0.1.0)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-unknown-pragmas")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-unknown-pragmas -Wextra -pedantic -pedantic-errors -std=gnu99")
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
 

--- a/odroid-ioctl/energymon-odroid-ioctl.c
+++ b/odroid-ioctl/energymon-odroid-ioctl.c
@@ -71,6 +71,7 @@ typedef struct energymon_odroid_ioctl {
 } energymon_odroid_ioctl;
 
 static inline int set_sensor_enable(ina231_sensor_t* sensor, int enable) {
+  sensor->data.enable = enable ? 1 : 0;
   return ioctl(sensor->fd, INA231_IOCSSTATUS, &sensor->data) < 0;
 }
 

--- a/rapl/energymon-rapl.c
+++ b/rapl/energymon-rapl.c
@@ -40,7 +40,7 @@ typedef struct rapl_zone {
 } rapl_zone;
 
 typedef struct energymon_rapl {
-  int count;
+  unsigned int count;
   rapl_zone zones[];
 } energymon_rapl;
 

--- a/src/app/energymon.c
+++ b/src/app/energymon.c
@@ -26,8 +26,13 @@ static void print_usage(const char* app) {
   fprintf(stderr, "  %s <output_file>\n", app);
 }
 
-void shandle(int dummy) {
-  running = 0;
+void shandle(int sig) {
+  switch (sig) {
+    case SIGTERM:
+      running = 0;
+    default:
+      break;
+  }
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Includes bug fix in odroid-ioctl and safety change in rapl implementations.
Only quit on SIGTERM signal in energymon app.