### PR TITLE
Add wattsup-libusb and wattsup-libftdi implementations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
       - autoconf
       - automake
       - libtool
+      - libftdi-dev
 
 before_install:
   - wget https://github.com/signal11/hidapi/archive/master.zip -O /tmp/hidapi.zip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,11 +69,13 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|Android")
   add_subdirectory(odroid)
   add_subdirectory(osp)
   add_subdirectory(rapl)
+endif()
+
+if(UNIX OR WIN32)
   add_subdirectory(wattsup)
 endif()
 
 # Binaries
-
 
 add_executable(energymon-info src/app/energymon-info.c)
 target_link_libraries(energymon-info energymon-default)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Current EnergyMon implementation options are:
 * rapl
 * shmem
 * wattsup
+* wattsup-libusb
+* wattsup-libftdi
 
 ## Building
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ configuration:
   - Release
 
 before_build:
+  # TODO: Install optional dependencies like hidapi-libusb, libusb-1.0, libftdi
   # Workaround for CMake not wanting sh.exe on PATH for MinGW
   - set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
   - set PATH=C:\MinGW\bin;%PATH%

--- a/wattsup/CMakeLists.txt
+++ b/wattsup/CMakeLists.txt
@@ -1,8 +1,3 @@
-set(LNAME energymon-wattsup)
-set(SHMEM_PROVIDER ${LNAME}-shmem-provider)
-set(SOURCES ${LNAME}.c;../src/energymon-util.c;../src/energymon-time-util.c)
-set(DESCRIPTION "EnergyMon implementation for WattsUp? Power meters")
-
 # Dependencies
 
 # Must be set to OFF to prevent doing a try_run() during cross-compiling
@@ -17,26 +12,15 @@ endif()
 
 # Libraries
 
-add_library(${LNAME} ${SOURCES})
-target_link_libraries(${LNAME} ${CMAKE_THREAD_LIBS_INIT} ${LIBRT})
-
-if(DEFAULT STREQUAL "wattsup" OR DEFAULT STREQUAL LNAME)
-  BUILD_DEFAULT("${SOURCES}" "${CMAKE_THREAD_LIBS_INIT};${LIBRT}" "")
-  PKG_CONFIG("energymon-default" "${DESCRIPTION}" "" "${PKG_CONFIG_PRIVATE_LIBS}")
-  install(TARGETS energymon-default DESTINATION lib)
+if(UNIX)
+  add_subdirectory(dev)
 endif()
-
-# pkg-config
-
-PKG_CONFIG("${LNAME}" "${DESCRIPTION}" "" "${PKG_CONFIG_PRIVATE_LIBS}")
-
-# Binaries
-
-add_executable(${SHMEM_PROVIDER} energymon-wattsup-shmem-provider.c)
-target_link_libraries(${SHMEM_PROVIDER} ${LNAME})
+if(UNIX OR WIN32)
+  add_subdirectory(libftdi)
+  add_subdirectory(libusb)
+endif()
 
 # Install
 
-install(TARGETS ${LNAME} DESTINATION lib)
-install(TARGETS ${SHMEM_PROVIDER} DESTINATION bin)
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${LNAME}.h DESTINATION include/${PROJECT_NAME})
+# TODO: Don't install headers if no implementation is built
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/energymon-wattsup.h DESTINATION include/${PROJECT_NAME})

--- a/wattsup/README.md
+++ b/wattsup/README.md
@@ -1,31 +1,65 @@
 # Watts up? Energy Monitor
 
-This implementation of the `energymon` interface polls power from `Watts up?`
-power meters connected by USB in Linux systems.
+These implementations of the `energymon` interface poll power from `Watts up?` power meters connected by USB.
+
+There are three implementations that are mutually exclusive:
+
+* `energymon-wattsup` - Interfaces with the /dev filesystem on Linux
+* `energymon-wattsup-libusb` - Uses [libusb-1.0](http://www.libusb.org/wiki/libusb-1.0)
+* `energymon-wattsup-libftdi` - Uses [libftdi](https://www.intra2net.com/en/developer/libftdi/) (WattsUp devices use a FTDI FT232R USB to serial UART IC internally)
 
 ## Prerequisites
 
 You need a `Watts up?` power meter with a USB connection.
 This has been tested on a `Watts up? PRO ES` device.
 
+To use `energymon-wattsup-libusb`, `libusb-1.0` (and development headers) must be discoverable by `pkg-config`.
+On Ubuntu systems, install `libusb-1.0-0-dev`.
+
+To use `energymon-wattsup-libftdi`, `libftdi` or `libftdi1` (and development headers) must be discoverable by `pkg-config`.
+On Ubuntu systems, install `libftdi1-dev` (links with `libusb-1.0`) or the older `libftdi-dev` (links with `libusb-0.1`).
+
+### Privileges
+
+Typically, sudo/root privileges are needed to read and write from the USB device file, e.g. `/dev/ttyUSB0`.
+To use `energymon-wattsup` without sudo/root at runtime, you can add your user to the file owner's group.
+For example, if the device file is owned by `root:dialout` and the file permissions permit both reading and writing by the group owner (`dialout`), then add the current user to the `dialout` group:
+
+```sh
+sudo usermod -a -G dialout $USER
+```
+
+The user may need to logout and log back in for the permission changes to take effect.
+
+To use the `libusb` or `libftdi` libraries without using sudo/root at runtime, set appropriate [udev](https://en.wikipedia.org/wiki/Udev) privileges.
+Following the prior example, force the WattsUp device to mount with `dialout` as the group owner:
+
+```sh
+sudo sh -c 'echo "# WattsUp? PRO USB device\nSUBSYSTEMS==\"usb\", ATTRS{idVendor}==\"0403\", ATTRS{idProduct}==\"6001\", GROUP=\"dialout\"" >> /etc/udev/rules.d/10-local.rules'
+```
+
+The WattsUp device probably needs to be disconnected and reconnected, or the system rebooted, for the change to take effect (the device must be remounted by the kernel with the new permissions).
+
 ## Usage
 
 `Watts up?` devices refresh about once per second.
-The documentation specifies that the device will respond to requests within 2
-seconds.
-As a result, it's possible that energy data could be delayed by up to 2-3
-seconds from the actual power behavior.
+The documentation specifies that the device will respond to requests within 2 seconds.
+As a result, it's possible that energy data could be delayed by up to 2-3 seconds from the actual power behavior.
 
-By default, the implementation looks for the WattsUp device at `/dev/ttyUSB0`.
-To override, set the environment variable `ENERGYMON_WATTSUP_DEV_FILE` to the
-correct device file.
+By default, the `wattsup` implementation looks for the WattsUp device at `/dev/ttyUSB0`.
+To override, set the environment variable `ENERGYMON_WATTSUP_DEV_FILE` to the correct device file.
+
+The `libusb` implementation detaches the WattsUp device from the kernel (thus unmounting it from the /dev filesystem in Linux during runtime), then reattaches it when giving up the device during teardown (but only if it was found to be attached during initialization).
+The `libftdi` version does not have this capability - if you need to reattach the device to the kernel, run the `energymon-wattsup-attach-kernel` binary (only available if `libusb-1.0` is available).
 
 ## Linking
 
-To link with the library:
+To link with the appropriate library and its dependencies, use `pkg-config` to get the linker flags:
 
-```
--lenergymon-wattsup -lpthread
+```sh
+pkg-config --libs --static energymon-wattsup
+pkg-config --libs --static energymon-wattsup-libusb
+pkg-config --libs --static energymon-wattsup-libftdi
 ```
 
-Also need `-lrt` for glibc versions before 2.17.
+The `--static` flag is unnecessary when using dynamically linked libraries.

--- a/wattsup/dev/CMakeLists.txt
+++ b/wattsup/dev/CMakeLists.txt
@@ -1,0 +1,29 @@
+set(LNAME energymon-wattsup)
+set(SOURCES ../energymon-wattsup.c;wattsup-driver-dev.c;../../src/energymon-util.c;../../src/energymon-time-util.c)
+set(DESCRIPTION "EnergyMon implementation for WattsUp? Power meters")
+set(SHMEM_PROVIDER ${LNAME}-shmem-provider)
+
+# Dependencies
+
+include_directories(..)
+
+# Libraries
+
+add_library(${LNAME} ${SOURCES})
+target_link_libraries(${LNAME} ${CMAKE_THREAD_LIBS_INIT} ${LIBRT})
+PKG_CONFIG("${LNAME}" "${DESCRIPTION}" "" "${PKG_CONFIG_PRIVATE_LIBS}")
+install(TARGETS ${LNAME} DESTINATION lib)
+
+if(DEFAULT STREQUAL "wattsup" OR DEFAULT STREQUAL LNAME)
+  BUILD_DEFAULT("${SOURCES}" "${CMAKE_THREAD_LIBS_INIT};${LIBRT}" "")
+  PKG_CONFIG("energymon-default" "${DESCRIPTION}" "" "${PKG_CONFIG_PRIVATE_LIBS}")
+  install(TARGETS energymon-default DESTINATION lib)
+endif()
+
+# Binaries
+
+if(UNIX)
+  add_executable(${SHMEM_PROVIDER} ../energymon-wattsup-shmem-provider.c)
+  target_link_libraries(${SHMEM_PROVIDER} ${LNAME})
+  install(TARGETS ${SHMEM_PROVIDER} DESTINATION bin)
+endif()

--- a/wattsup/dev/wattsup-driver-dev.c
+++ b/wattsup/dev/wattsup-driver-dev.c
@@ -1,0 +1,182 @@
+/**
+ * Use the Linux /dev filesystem to communicate with a Watts Up? Power Meter.
+ *
+ * @author Connor Imes
+ * @date 2016-02-08
+ */
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/stat.h>
+#include <termios.h>
+#include <unistd.h>
+#include "energymon-util.h"
+#include "wattsup-driver.h"
+
+struct energymon_wattsup_ctx {
+  struct timeval timeout;
+  int fd;
+};
+
+static int wattsup_open(const char* filename, int* fd) {
+  assert(filename != NULL);
+  assert(fd != NULL);
+
+  struct stat s;
+  char buf[32];
+  const char* shortname;
+
+  // Check if device node exists and is writable
+  if (stat(filename, &s) < 0) {
+    perror(filename);
+    return -1;
+  }
+  if (!S_ISCHR(s.st_mode)) {
+    errno = ENOTTY;
+    perror("wattsup_open: Not a TTY character device");
+    return -1;
+  }
+  if (access(filename, R_OK | W_OK)) {
+    perror(filename);
+    return -1;
+  }
+
+  // Get shortname by dropping leading "/dev/"
+  if (!(shortname = strrchr(filename, '/'))) {
+    // shouldn't happen since we've already checked filename
+    errno = EINVAL;
+    perror(filename);
+    return -1;
+  }
+  shortname++;
+
+  // Check if "/sys/class/tty/<shortname>" exists and is correct type
+  snprintf(buf, sizeof(buf), "/sys/class/tty/%s", shortname);
+  if (stat(buf, &s) < 0) {
+    perror(buf);
+    return -1;
+  }
+  if (!S_ISDIR(s.st_mode)) {
+    errno = ENODEV;
+    perror("wattsup_open: Not a TTY device");
+    return -1;
+  }
+
+  // Open the device file
+  *fd = open(filename, O_RDWR | O_NONBLOCK);
+  if (*fd < 0) {
+    perror(filename);
+    return -1;
+  }
+  return 0;
+}
+
+static int wattsup_set_serial_attributes(int fd) {
+  assert(fd > 0);
+  struct termios t;
+  // get attributes
+  if (tcgetattr(fd, &t)) {
+    return -1;
+  }
+  // set "raw" mode
+  cfmakeraw(&t);
+  // set input/output baud rate
+  cfsetispeed(&t, B115200);
+  cfsetospeed(&t, B115200);
+  // flush any data received but not read
+  tcflush(fd, TCIFLUSH);
+  // ignore framing and parity errors (there is no parity bit)
+  t.c_iflag |= IGNPAR;
+  // Turn off double stop bits (documentation specifies only one is used)
+  t.c_cflag &= ~CSTOPB;
+
+  // set the parameters (immediately)
+  return tcsetattr(fd, TCSANOW, &t);
+}
+
+energymon_wattsup_ctx* wattsup_connect(const char* dev_file, unsigned int timeout_ms) {
+  assert(dev_file != NULL);
+  int err_save;
+  energymon_wattsup_ctx* ctx = malloc(sizeof(energymon_wattsup_ctx));
+  if (ctx == NULL) {
+    return NULL;
+  }
+
+  // set read timeout
+  ctx->timeout.tv_sec = timeout_ms / 1000;
+  ctx->timeout.tv_usec = timeout_ms % 1000;
+
+  // open the file descriptor and check device properties
+  if (wattsup_open(dev_file, &ctx->fd)) {
+    perror(dev_file);
+    free(ctx);
+    return NULL;
+  }
+
+  // set serial port configuration
+  if (wattsup_set_serial_attributes(ctx->fd)) {
+    perror(dev_file);
+    err_save = errno;
+    close(ctx->fd);
+    free(ctx);
+    errno = err_save;
+    return NULL;
+  }
+
+  return ctx;
+}
+
+int wattsup_disconnect(energymon_wattsup_ctx* ctx) {
+  assert(ctx != NULL);
+  int ret = ctx->fd > 0 ? close(ctx->fd) : 0;
+  free(ctx);
+  return ret;
+}
+
+int wattsup_read(energymon_wattsup_ctx* ctx, char* buf, size_t buflen) {
+  assert(ctx != NULL);
+  assert(ctx->fd > 0);
+  assert(buf != NULL);
+  assert(buflen > 0);
+
+  int ret = -1;
+  fd_set set;
+  FD_ZERO(&set);
+  FD_SET(ctx->fd, &set);
+
+  switch (select(ctx->fd + 1, &set, NULL, NULL, &ctx->timeout)) {
+    case -1:
+      // failed
+      break;
+    case 0:
+      // timed out
+      errno = ETIME;
+      break;
+    default:
+      ret = read(ctx->fd, buf, buflen);
+      if (!ret) {
+        // no data was read
+        ret = -1;
+        errno = ENODATA;
+      }
+      break;
+  }
+  return ret;
+}
+
+int wattsup_write(energymon_wattsup_ctx* ctx, const char* buf, size_t buflen) {
+  assert(ctx != NULL);
+  assert(ctx->fd > 0);
+  assert(buf != NULL);
+  assert(buflen > 0);
+  return write(ctx->fd, buf, buflen);
+}
+
+char* wattsup_get_implementation(char* buf, size_t buflen) {
+  return energymon_strencpy(buf, "WattsUp? Power Meter", buflen);
+}

--- a/wattsup/energymon-wattsup.h
+++ b/wattsup/energymon-wattsup.h
@@ -17,7 +17,9 @@ extern "C" {
 
 // Environment variable for specifying the device file to read from
 #define ENERGYMON_WATTSUP_DEV_FILE "ENERGYMON_WATTSUP_DEV_FILE"
-#define ENERGYMON_WATTSUP_DEV_FILE_DEFAULT "/dev/ttyUSB0"
+#ifndef ENERGYMON_WATTSUP_DEV_FILE_DEFAULT
+  #define ENERGYMON_WATTSUP_DEV_FILE_DEFAULT "/dev/ttyUSB0"
+#endif
 
 int energymon_init_wattsup(energymon* em);
 

--- a/wattsup/libftdi/CMakeLists.txt
+++ b/wattsup/libftdi/CMakeLists.txt
@@ -1,0 +1,46 @@
+set(LNAME energymon-wattsup-libftdi)
+set(SOURCES_LIBFTDI ../energymon-wattsup.c;wattsup-driver-libftdi.c;../../src/energymon-util.c;../../src/energymon-time-util.c)
+set(DESCRIPTION_FTDI "EnergyMon implementation for WattsUp? Power meters using libftdi")
+set(SHMEM_PROVIDER ${LNAME}-shmem-provider)
+
+# Dependencies
+
+set(FTDI_IMPL libftdi1)
+
+find_package(PkgConfig)
+if(${PKG_CONFIG_FOUND})
+  pkg_search_module(LIBFTDI libftdi1)
+  if(NOT LIBFTDI_FOUND)
+    set(FTDI_IMPL libftdi)
+    pkg_search_module(LIBFTDI libftdi)
+  endif()
+endif()
+
+if(NOT LIBFTDI_FOUND)
+  # fail gracefully
+  message(WARNING "${LNAME}: No libftdi1 or libftdi - skipping this project")
+  return()
+endif()
+
+include_directories(.. ${LIBFTDI_INCLUDE_DIRS})
+
+# Libraries
+
+add_library(${LNAME} ${SOURCES_LIBFTDI})
+target_link_libraries(${LNAME} ${CMAKE_THREAD_LIBS_INIT} ${LIBRT} ${LIBFTDI_LIBRARIES})
+PKG_CONFIG("${LNAME}" "${DESCRIPTION_LIBFTDI}" "${FTDI_IMPL}" "${PKG_CONFIG_PRIVATE_LIBS}")
+install(TARGETS ${LNAME} DESTINATION lib)
+
+if(DEFAULT STREQUAL "wattsup-libftdi" OR DEFAULT STREQUAL LNAME)
+  BUILD_DEFAULT("${SOURCES_LIBFTDI}" "${CMAKE_THREAD_LIBS_INIT};${LIBRT};${LIBFTDI_LIBRARIES}" "")
+  PKG_CONFIG("energymon-default" "${DESCRIPTION_LIBFTDI}" "${FTDI_IMPL}" "${PKG_CONFIG_PRIVATE_LIBS}")
+  install(TARGETS energymon-default DESTINATION lib)
+endif()
+
+# Binaries
+
+if(UNIX)
+  add_executable(${SHMEM_PROVIDER} ../energymon-wattsup-shmem-provider.c)
+  target_link_libraries(${SHMEM_PROVIDER} ${LNAME})
+  install(TARGETS ${SHMEM_PROVIDER} DESTINATION bin)
+endif()

--- a/wattsup/libftdi/wattsup-driver-libftdi.c
+++ b/wattsup/libftdi/wattsup-driver-libftdi.c
@@ -1,0 +1,120 @@
+/**
+ * Use libftdi to communicate with a Watts Up? Power Meter.
+ *
+ * @author Connor Imes
+ * @date 2017-01-27
+ */
+#include <assert.h>
+#include <errno.h>
+#include <ftdi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "energymon-util.h"
+#include "wattsup-driver.h"
+
+// undocumented environment variable to force setting serial attributes like baud rate
+#define WATTSUP_LIBFTDI_SET_SERIAL_ATTRIBUTES "WATTSUP_LIBFTDI_SET_SERIAL_ATTRIBUTES"
+
+#ifndef ENERGYMON_WATTSUP_BAUD_RATE
+  #define ENERGYMON_WATTSUP_BAUD_RATE 115200
+#endif
+
+struct energymon_wattsup_ctx {
+  struct ftdi_context* ctx;
+};
+
+static int ctx_destroy(energymon_wattsup_ctx* ctx, int opened) {
+  assert(ctx != NULL);
+  int ret = 0;
+  if (ctx->ctx != NULL) {
+    if (opened && (ret = ftdi_usb_close(ctx->ctx)) < 0) {
+      fprintf(stderr, "ftdi_usb_close: %s\n", ftdi_get_error_string(ctx->ctx));
+    }
+    ftdi_free(ctx->ctx);
+  }
+  free(ctx);
+  return ret;
+}
+
+static energymon_wattsup_ctx* init_failed(const char* err, energymon_wattsup_ctx* ctx, int opened) {
+  assert(ctx != NULL);
+  int err_save = errno;
+  if (errno) {
+    perror(err);
+  }
+  fprintf(stderr, "%s: %s\n", err, ftdi_get_error_string(ctx->ctx));
+  ctx_destroy(ctx, opened);
+  errno = err_save;
+  return NULL;
+}
+
+energymon_wattsup_ctx* wattsup_connect(const char* dev_file, unsigned int timeout_ms) {
+  (void) dev_file;
+  energymon_wattsup_ctx* ctx = malloc(sizeof(energymon_wattsup_ctx));
+  if (ctx == NULL) {
+    return NULL;
+  }
+
+  // create a ftdi context
+  if ((ctx->ctx = ftdi_new()) == NULL) {
+    return init_failed("ftdi_new", ctx, 0);
+  }
+
+  // TODO: No API to set read/write timeouts?
+  (void) timeout_ms;
+  // set read/write timeout
+  // ctx->ctx->usb_read_timeout = timeout_ms;
+  // ctx->ctx->usb_write_timeout = timeout_ms;
+
+  // find the device and open it
+  if (ftdi_usb_open(ctx->ctx, ENERGYMON_WATTSUP_VENDOR_ID, ENERGYMON_WATTSUP_PRODUCT_ID) < 0) {
+    return init_failed("ftdi_usb_open", ctx, 0);
+  }
+
+  // We don't appear to need to set the following, so we'll only do so if requested
+  if (getenv(WATTSUP_LIBFTDI_SET_SERIAL_ATTRIBUTES) != NULL) {
+    // configure baud rate
+    if (ftdi_set_baudrate(ctx->ctx, ENERGYMON_WATTSUP_BAUD_RATE) < 0) {
+      return init_failed("ftdi_set_baudrate", ctx, 1);
+    }
+    // ftdi example "serial_test" also does this for writing to this same vid/pid
+    if (ftdi_set_line_property(ctx->ctx, BITS_8, STOP_BIT_1, NONE)) {
+      return init_failed("ftdi_set_line_property", ctx, 1);
+    }
+  }
+
+  return ctx;
+}
+
+int wattsup_disconnect(energymon_wattsup_ctx* ctx) {
+  assert(ctx != NULL);
+  return ctx_destroy(ctx, 1);
+}
+
+int wattsup_read(energymon_wattsup_ctx* ctx, char* buf, size_t buflen) {
+  assert(ctx != NULL);
+  assert(ctx->ctx != NULL);
+  assert(buf != NULL);
+  assert(buflen > 0);
+  int rc = ftdi_read_data(ctx->ctx, (unsigned char*) buf, buflen);
+  if (rc < 0) {
+    fprintf(stderr, "ftdi_read_data: %s\n", ftdi_get_error_string(ctx->ctx));
+  }
+  return rc;
+}
+
+int wattsup_write(energymon_wattsup_ctx* ctx, const char* buf, size_t buflen) {
+  assert(ctx != NULL);
+  assert(ctx->ctx != NULL);
+  assert(buf != NULL);
+  assert(buflen > 0);
+  int rc = ftdi_write_data(ctx->ctx, (unsigned char*) buf, buflen);
+  if (rc < 0) {
+    fprintf(stderr, "ftdi_write_data: %s\n", ftdi_get_error_string(ctx->ctx));
+  }
+  return rc;
+}
+
+char* wattsup_get_implementation(char* buf, size_t buflen) {
+  return energymon_strencpy(buf, "WattsUp? Power Meter over libftdi", buflen);
+}

--- a/wattsup/libusb/CMakeLists.txt
+++ b/wattsup/libusb/CMakeLists.txt
@@ -1,0 +1,44 @@
+set(LNAME energymon-wattsup-libusb)
+set(SOURCES_LIBUSB ../energymon-wattsup.c;wattsup-driver-libusb.c;../../src/energymon-util.c;../../src/energymon-time-util.c)
+set(DESCRIPTION_LIBUSB "EnergyMon implementation for WattsUp? Power meters using libusb-1.0")
+set(SHMEM_PROVIDER ${LNAME}-shmem-provider)
+
+# Dependencies
+
+find_package(PkgConfig)
+if(${PKG_CONFIG_FOUND})
+  pkg_search_module(LIBUSB_1 libusb-1.0)
+endif()
+
+if(NOT LIBUSB_1_FOUND)
+  # fail gracefully
+  message(WARNING "${LNAME}: No libusb-1.0 - skipping this project")
+  return()
+endif()
+
+include_directories(.. ${LIBUSB_1_INCLUDE_DIRS})
+
+# Libraries
+
+add_library(${LNAME} ${SOURCES_LIBUSB})
+target_link_libraries(${LNAME} ${CMAKE_THREAD_LIBS_INIT} ${LIBRT} ${LIBUSB_1_LIBRARIES})
+PKG_CONFIG("${LNAME}" "${DESCRIPTION_LIBUSB}" "libusb-1.0" "${PKG_CONFIG_PRIVATE_LIBS}")
+install(TARGETS ${LNAME} DESTINATION lib)
+
+if(DEFAULT STREQUAL "wattsup-libusb" OR DEFAULT STREQUAL LNAME)
+  BUILD_DEFAULT("${SOURCES_LIBUSB}" "${CMAKE_THREAD_LIBS_INIT};${LIBRT};${LIBUSB_1_LIBRARIES}" "")
+  PKG_CONFIG("energymon-default" "${DESCRIPTION_LIBUSB}" "libusb-1.0" "${PKG_CONFIG_PRIVATE_LIBS}")
+  install(TARGETS energymon-default DESTINATION lib)
+endif()
+
+# Binaries
+
+if(UNIX)
+  add_executable(${SHMEM_PROVIDER} ../energymon-wattsup-shmem-provider.c)
+  target_link_libraries(${SHMEM_PROVIDER} ${LNAME})
+  install(TARGETS ${SHMEM_PROVIDER} DESTINATION bin)
+endif()
+
+add_executable(energymon-wattsup-attach-kernel wattsup-attach-kernel.c)
+target_link_libraries(energymon-wattsup-attach-kernel ${LIBUSB_1_LIBRARIES})
+install(TARGETS energymon-wattsup-attach-kernel DESTINATION bin)

--- a/wattsup/libusb/wattsup-attach-kernel.c
+++ b/wattsup/libusb/wattsup-attach-kernel.c
@@ -1,0 +1,44 @@
+/**
+ * Utility to attach a WattsUp device to the kernel if it's currently detached.
+ *
+ * @author Connor Imes
+ * @date 2017-01-28
+ */
+#include <errno.h>
+#include <libusb.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// vendor and product IDs
+#define VID 0x0403
+#define PID 0x6001
+
+#define INTERFACE_NUMBER 0
+
+int main(void) {
+  libusb_context* ctx;
+  libusb_device_handle* handle;
+  int rc;
+
+  if ((rc = libusb_init(&ctx)) < 0) {
+    fprintf(stderr, "libusb_init: %s\n", libusb_error_name(rc));
+    return rc;
+  }
+
+  if ((handle = libusb_open_device_with_vid_pid(ctx, VID, PID)) == NULL) {
+    perror("libusb_open_device_with_vid_pid");
+    return -errno;
+  }
+
+  if (libusb_kernel_driver_active(handle, INTERFACE_NUMBER) == 0) {
+    if ((rc = libusb_attach_kernel_driver(handle, INTERFACE_NUMBER)) < 0) {
+      fprintf(stderr, "libusb_attach_kernel_driver: %s\n", libusb_error_name(rc));
+      return rc;
+    }
+  }
+
+  libusb_close(handle);
+  libusb_exit(ctx);
+
+  return 0;
+}

--- a/wattsup/libusb/wattsup-driver-libusb.c
+++ b/wattsup/libusb/wattsup-driver-libusb.c
@@ -1,0 +1,201 @@
+/**
+ * Use libusb to communicate with a Watts Up? Power Meter.
+ *
+ * @author Connor Imes
+ * @date 2017-01-27
+ */
+#include <assert.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <libusb.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "energymon-util.h"
+#include "wattsup-driver.h"
+
+#ifndef ENERGYMON_WATTSUP_INTERFACE_NUMBER
+  #define ENERGYMON_WATTSUP_INTERFACE_NUMBER 0
+#endif
+
+#ifndef ENERGYMON_WATTSUP_ENDPOINT_WRITE
+  #define ENERGYMON_WATTSUP_ENDPOINT_WRITE 0x02
+#endif
+
+#ifndef ENERGYMON_WATTSUP_ENDPOINT_READ
+  #define ENERGYMON_WATTSUP_ENDPOINT_READ 0x81
+#endif
+
+// undocumented environment variable to force setting serial attributes like baud rate
+#define WATTSUP_LIBUSB_SET_SERIAL_ATTRIBUTES "WATTSUP_LIBUSB_SET_SERIAL_ATTRIBUTES"
+
+struct energymon_wattsup_ctx {
+  libusb_context* ctx;
+  libusb_device_handle* handle;
+  int reattach_kernel;
+  unsigned int timeout_ms;
+  int interface;
+  unsigned char endpoint_r;
+  unsigned char endpoint_w;
+};
+
+static int ctx_destroy(energymon_wattsup_ctx* ctx, int claimed) {
+  assert(ctx != NULL);
+  int rc;
+  int ret = 0;
+  if (ctx->handle != NULL) {
+    // release our claim
+    if (claimed && (rc = libusb_release_interface(ctx->handle, ctx->interface)) < 0) {
+      fprintf(stderr, "libusb_release_interface: %s\n", libusb_error_name(rc));
+      ret |= rc;
+    }
+    // reattach kernel driver if we detached it
+    if (ctx->reattach_kernel && (rc = libusb_attach_kernel_driver(ctx->handle, ctx->interface)) < 0) {
+      fprintf(stderr, "libusb_attach_kernel_driver: %s\n", libusb_error_name(rc));
+      ret |= rc;
+    }
+    // close the device handle
+    libusb_close(ctx->handle);
+  }
+  if (ctx->ctx != NULL) {
+    // destroy the libusb context
+    libusb_exit(ctx->ctx);
+  }
+  free(ctx);
+  return ret;
+}
+
+static energymon_wattsup_ctx* init_failed(const char* err, int code, energymon_wattsup_ctx* ctx, int claimed) {
+  assert(ctx != NULL);
+  int err_save = errno;
+  if (code == 0) {
+    perror(err);
+  } else {
+    fprintf(stderr, "%s: %s\n", err, libusb_error_name(code));
+  }
+  ctx_destroy(ctx, claimed);
+  errno = err_save;
+  return NULL;
+}
+
+energymon_wattsup_ctx* wattsup_connect(const char* dev_file, unsigned int timeout_ms) {
+  (void) dev_file;
+  energymon_wattsup_ctx* ctx = calloc(1, sizeof(energymon_wattsup_ctx));
+  if (ctx == NULL) {
+    return NULL;
+  }
+  int rc;
+
+  // set read/write timeout
+  ctx->timeout_ms = timeout_ms;
+  // set the interface number and read/write endpoints
+  ctx->interface = ENERGYMON_WATTSUP_INTERFACE_NUMBER;
+  ctx->endpoint_r = ENERGYMON_WATTSUP_ENDPOINT_READ;
+  ctx->endpoint_w = ENERGYMON_WATTSUP_ENDPOINT_WRITE;
+
+  // initialize libusb
+  if ((rc = libusb_init(&ctx->ctx)) < 0) {
+    return init_failed("libusb_init", rc, ctx, 0);
+  }
+
+  /*
+   * TODO: docs say "libusb_open_device_with_vid_pid" is a convenience function that shouldn't be used in real apps.
+   * It returns the first vid/pid match found, but there could be more than one connected to the system.
+   * Instead we should use "libusb_get_device_list" and search for our device there.
+   * However, I don't know what we can get from that list other than vid/pid to better identify a WattsUp.
+   */
+  // find the device and open a handle
+  if ((ctx->handle = libusb_open_device_with_vid_pid(ctx->ctx, ENERGYMON_WATTSUP_VENDOR_ID, ENERGYMON_WATTSUP_PRODUCT_ID)) == NULL) {
+    return init_failed("libusb_open_device_with_vid_pid", 0, ctx, 0);
+  }
+
+  // check if the device is currently in the /dev filesystem (Linux usually mounts it there by default)
+  if (libusb_kernel_driver_active(ctx->handle, ctx->interface) == 1) {
+    // we must detach it from there so we can use it
+    if ((rc = libusb_detach_kernel_driver(ctx->handle, ctx->interface)) != 0) {
+      return init_failed("libusb_detach_kernel_driver", rc, ctx, 0);
+    }
+    // remember to reattach it when we disconnect
+    ctx->reattach_kernel = 1;
+  }
+
+  // must claim the interface to use it
+  if ((rc = libusb_claim_interface(ctx->handle, ctx->interface)) < 0) {
+    return init_failed("libusb_claim_interface", rc, ctx, 0);
+  }
+
+  // TODO: stil getting some junk characters during reading - see ftdi_read_data(), packet size = 64
+
+  // We don't appear to need to set the following, so we'll only do so if requested
+  if (getenv(WATTSUP_LIBUSB_SET_SERIAL_ATTRIBUTES) != NULL) {
+    // reverse-engineered these calls and parameters from libftdi
+    // reset the device
+    static const uint8_t RESET_REQUEST = 0;
+    static const uint16_t RESET_VALUE = 0;
+    static const uint16_t RESET_INDEX = 0;
+    if (libusb_control_transfer(ctx->handle, (LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | LIBUSB_ENDPOINT_OUT), RESET_REQUEST,
+                                RESET_VALUE, RESET_INDEX,
+                                NULL, 0,
+                                ctx->timeout_ms) < 0) {
+      return init_failed("libusb_control_transfer: reset", rc, ctx, 1);
+    }
+    // set baud rate
+    static const uint8_t SET_BAUD_RATE_REQUEST = 3;
+    static const uint16_t BAUD_RATE_CONVERTED = 26;
+    static const int BAUD_RATE_INDEX = 0;
+    if (libusb_control_transfer(ctx->handle,
+                                (LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | LIBUSB_ENDPOINT_OUT), SET_BAUD_RATE_REQUEST,
+                                BAUD_RATE_CONVERTED, BAUD_RATE_INDEX,
+                                NULL, 0,
+                                ctx->timeout_ms) < 0) {
+      return init_failed("libusb_control_transfer: baud", rc, ctx, 1);
+    }
+    static const uint8_t SET_DATA_REQUEST = 4;
+    static const uint16_t LINE_PROPERTIES_VALUE = 8;
+    static const uint16_t LINE_PROPERTIES_INDEX = 8;
+    // configure serial line properties
+    if (libusb_control_transfer(ctx->handle,
+                                (LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | LIBUSB_ENDPOINT_OUT), SET_DATA_REQUEST,
+                                LINE_PROPERTIES_VALUE, LINE_PROPERTIES_INDEX,
+                                NULL, 0,
+                                ctx->timeout_ms) < 0) {
+      return init_failed("libusb_control_transfer: line properties", rc, ctx, 1);
+    }
+  }
+
+  return ctx;
+}
+
+int wattsup_disconnect(energymon_wattsup_ctx* ctx) {
+  assert(ctx != NULL);
+  return ctx_destroy(ctx, 1);
+}
+
+int wattsup_read(energymon_wattsup_ctx* ctx, char* buf, size_t buflen) {
+  assert(ctx != NULL);
+  assert(ctx->handle != NULL);
+  assert(buf != NULL);
+  assert(buflen > 0);
+  int actual = 0;
+  int rc = libusb_bulk_transfer(ctx->handle, (ctx->endpoint_r | LIBUSB_ENDPOINT_IN), (unsigned char*) buf, buflen, &actual, ctx->timeout_ms);
+  if (rc < 0) {
+    fprintf(stderr, "wattsup_read:libusb_bulk_transfer: %s\n", libusb_error_name(rc));
+  }
+  return actual;
+}
+
+int wattsup_write(energymon_wattsup_ctx* ctx, const char* buf, size_t buflen) {
+  assert(ctx != NULL);
+  assert(ctx->handle != NULL);
+  assert(buf != NULL);
+  assert(buflen > 0);
+  int actual = 0;
+  int rc = libusb_bulk_transfer(ctx->handle, (ctx->endpoint_w | LIBUSB_ENDPOINT_OUT), (unsigned char*) buf, buflen, &actual, ctx->timeout_ms);
+  if (rc < 0) {
+    fprintf(stderr, "wattsup_write:libusb_bulk_transfer: %s\n", libusb_error_name(rc));
+  }
+  return actual;
+}
+
+char* wattsup_get_implementation(char* buf, size_t buflen) {
+  return energymon_strencpy(buf, "WattsUp? Power Meter over libusb-1.0", buflen);
+}

--- a/wattsup/libusb/wattsup-libusb-device.txt
+++ b/wattsup/libusb/wattsup-libusb-device.txt
@@ -1,0 +1,34 @@
+# WattsUp? PRO device information
+# Captured using the "testlibusb -v" example program in libusb
+
+Dev (bus 2, device 2): FTDI - FT232R USB UART
+  - Serial Number: A5015A7F
+  Configuration:
+    wTotalLength:         32
+    bNumInterfaces:       1
+    bConfigurationValue:  1
+    iConfiguration:       0
+    bmAttributes:         a0h
+    MaxPower:             45
+    Interface:
+      bInterfaceNumber:   0
+      bAlternateSetting:  0
+      bNumEndpoints:      2
+      bInterfaceClass:    255
+      bInterfaceSubClass: 255
+      bInterfaceProtocol: 255
+      iInterface:         2
+      Endpoint:
+        bEndpointAddress: 81h
+        bmAttributes:     02h
+        wMaxPacketSize:   64
+        bInterval:        0
+        bRefresh:         0
+        bSynchAddress:    0
+      Endpoint:
+        bEndpointAddress: 02h
+        bmAttributes:     02h
+        wMaxPacketSize:   64
+        bInterval:        0
+        bRefresh:         0
+        bSynchAddress:    0

--- a/wattsup/wattsup-driver.h
+++ b/wattsup/wattsup-driver.h
@@ -1,0 +1,107 @@
+/**
+* Energy reading from a Watts Up? device.
+*
+* @author Connor Imes
+* @date 2017-01-27
+*/
+#ifndef _WATTSUP_DRIVER_H_
+#define _WATTSUP_DRIVER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+
+#ifndef ENERGYMON_WATTSUP_VENDOR_ID
+  // vendor id is "Future Technology Devices International, Ltd"
+  #define ENERGYMON_WATTSUP_VENDOR_ID 0x0403
+#endif
+
+#ifndef ENERGYMON_WATTSUP_PRODUCT_ID
+  // product id is "FT232 Serial (UART) IC"
+  #define ENERGYMON_WATTSUP_PRODUCT_ID 0x6001
+#endif
+
+#ifndef ENERGYMON_WATTSUP_TIMEOUT_MS
+  // documentation specifies response within 2 seconds
+  #define ENERGYMON_WATTSUP_TIMEOUT_MS 2000
+#endif
+
+#define WU_CLEAR "#R,W,0;"
+#define WU_LOG_START_EXTERNAL "#L,W,3,E,1,1;"
+#define WU_LOG_STOP "#L,W,0;"
+
+// opaque struct
+typedef struct energymon_wattsup_ctx energymon_wattsup_ctx;
+
+/**
+ * Allocate and initialize a new context and connect to the device.
+ * Not all implementations use the dev_File parameter.
+ *
+ * @param dev_file
+ *   The device file, e.g. "/dev/ttyUSB0"
+ * @param timeout_ms
+ *   The read and write timeout value to use
+ *
+ * @return the new context
+ */
+energymon_wattsup_ctx* wattsup_connect(const char* dev_file, unsigned int timeout_ms);
+
+/**
+ * Disconnect from the device and free the context
+ *
+ * @param ctx
+ *   Must not be NULL
+ *
+ * @return 0 on success, a negative value otherwise
+ */
+int wattsup_disconnect(energymon_wattsup_ctx* ctx);
+
+/**
+ * Read data from the WattsUp into the buffer.
+ * Returns the number of characters read, or a negative value on failure.
+ *
+ * @param ctx
+ *   Must not be NULL
+ * @param buf
+ *   Must not be NULL
+ * @param buflen
+ *   Must be > 0
+ *
+ * @return the number of characters read on success, a negative value otherwise
+ */
+int wattsup_read(energymon_wattsup_ctx* ctx, char* buf, size_t buflen);
+
+/**
+ * Write data to the WattsUp into the buffer.
+ * Returns the number of characters written, or a negative value on failure.
+ *
+ * @param ctx
+ *   Must not be NULL
+ * @param buf
+ *   Must not be NULL
+ * @param buflen
+ *   Must be > 0
+ *
+ * @return the number of characters written on success, a negative value otherwise
+ */
+int wattsup_write(energymon_wattsup_ctx* ctx, const char* buf, size_t buflen);
+
+/**
+ * Get a name for the implementation.
+ *
+ * @param buf
+ *   Must not be NULL
+ * @param buflen
+ *   Must be > 0
+ *
+ * @return a pointer to the buffer on success, NULL otherwise
+ */
+char* wattsup_get_implementation(char* buf, size_t buflen);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Adds some new implementations for reading from a WattsUp meter that, with proper system configurations, don't require sudo/root privileges.  They should, in theory, work on any system that supports libusb.  There are some outstanding TODOs that can be tackled, but the current state of the work is a solid improvement over what existed before and maintains compatibility.