### PR TITLE
Support for Xilinx ZCU102 eval board

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|Android")
   add_subdirectory(msr)
   add_subdirectory(odroid)
   add_subdirectory(rapl)
+  add_subdirectory(zcu102)
 endif()
 
 if(UNIX OR WIN32)

--- a/zcu102/CMakeLists.txt
+++ b/zcu102/CMakeLists.txt
@@ -1,0 +1,39 @@
+set(SNAME zcu102)
+set(LNAME energymon-zcu102)
+set(SOURCES ${LNAME}.c;${ENERGYMON_UTIL};${ENERGYMON_TIME_UTIL})
+set(DESCRIPTION "EnergyMon implementation for Xilinx ZCU102 systems")
+
+# Dependencies
+
+# Must be set to OFF to prevent doing a try_run() during cross-compiling
+set(THREADS_PTHREAD_ARG OFF)
+find_package(Threads)
+if(CMAKE_THREAD_LIBS_INIT)
+  set(PKG_CONFIG_PRIVATE_LIBS "${CMAKE_THREAD_LIBS_INIT}")
+endif()
+if(LIBRT)
+  set(PKG_CONFIG_PRIVATE_LIBS "${PKG_CONFIG_PRIVATE_LIBS} -lrt")
+endif()
+
+# Libraries
+
+if(ENERGYMON_BUILD_LIB STREQUAL "ALL" OR
+   ENERGYMON_BUILD_LIB STREQUAL SNAME OR
+   ENERGYMON_BUILD_LIB STREQUAL LNAME)
+
+  add_library(${LNAME} ${SOURCES})
+  target_link_libraries(${LNAME} ${CMAKE_THREAD_LIBS_INIT} ${LIBRT})
+  if(BUILD_SHARED_LIBS)
+    set_target_properties(${LNAME} PROPERTIES VERSION ${PROJECT_VERSION}
+                                              SOVERSION ${VERSION_MAJOR})
+  endif()
+  PKG_CONFIG("${LNAME}" "${DESCRIPTION}" "" "${PKG_CONFIG_PRIVATE_LIBS}")
+  install(TARGETS ${LNAME} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  install(FILES ${LNAME}.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
+
+endif()
+
+if(ENERGYMON_BUILD_DEFAULT STREQUAL SNAME OR ENERGYMON_BUILD_DEFAULT STREQUAL LNAME)
+  BUILD_DEFAULT("${SOURCES}" "${CMAKE_THREAD_LIBS_INIT};${LIBRT}" "")
+  PKG_CONFIG("energymon-default" "${DESCRIPTION}" "" "${PKG_CONFIG_PRIVATE_LIBS}")
+endif()

--- a/zcu102/README.md
+++ b/zcu102/README.md
@@ -1,0 +1,27 @@
+# ZCU102 Energy Monitor
+
+This implementation of the `energymon` interface reads from INA-226 power
+sensors on Xilinx ZCU102 evaluation boards running Linux.
+The power sensors are polled at regular intervals to estimate energy
+consumption.
+
+Thanks to Connor Imes for the odroid sysfs implementation on which this
+implementation is based.
+
+## Prerequisites
+
+You must be using a ZCU102 board running PetaLinux.
+
+## Usage
+
+No special setup is required.
+
+## Linking
+
+Add the following to your link flags:
+
+```
+-lenergymon-zcu102 -lpthread
+```
+
+You will also need `-lrt` for glibc versions before 2.17.

--- a/zcu102/energymon-zcu102.c
+++ b/zcu102/energymon-zcu102.c
@@ -126,16 +126,6 @@ int energymon_finish_zcu102(energymon* em) {
   return errno ? -1 : 0;
 }
 
-/**
- * Ignore non-directories and hidden/relative directories (. and ..).
- * We expect the folder name to be something like 3-0040 or 4-0045.
- */
-static inline int is_sensor_dir(struct dirent* entry) {
-  return (entry->d_type == DT_LNK || entry->d_type == DT_DIR)
-          && entry->d_name[0] != '.'
-          && entry->d_name[1] == '-';
-}
-
 static inline void free_sensor_directories(char** dirs, unsigned int n) {
   while (n > 0) {
     free(dirs[--n]);

--- a/zcu102/energymon-zcu102.c
+++ b/zcu102/energymon-zcu102.c
@@ -1,0 +1,342 @@
+/**
+ * Energy reading for a ZCU102 with INA226 power sensors.
+ *
+ * @author Jason Miller, Connor Imes
+ * @date 2017-02-14
+ */
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "energymon.h"
+#include "energymon-zcu102.h"
+#include "energymon-time-util.h"
+#include "energymon-util.h"
+
+#ifdef ENERGYMON_DEFAULT
+#include "energymon-default.h"
+int energymon_get_default(energymon* em) {
+  return energymon_get_zcu102(em);
+}
+#endif
+
+#define INA226_DIR "/sys/class/hwmon"
+// Alternate directory for power sensors (see get_sensor_directories)
+//#define INA226_DIR "/sys/bus/i2c/drivers/ina2xx"
+#define INA226_FILE_TEMPLATE_POWER INA226_DIR"/%s/power1_input"
+#define INA226_FILE_TEMPLATE_UPDATE_PERIOD INA226_DIR"/%s/update_interval"
+#define HWMON_DIR_EXAMPLE "hwmon999" // NOTE: allows for up to 1000 sensors
+#define INA226_DEFAULT_UPDATE_INTERVAL_US 35200
+
+//#define ENERGYMON_DEBUG 1
+
+typedef struct energymon_zcu102 {
+  // sensor update interval in microseconds
+  unsigned long read_delay_us;
+  // thread variables
+  pthread_t thread;
+  int poll_sensors;
+  // total energy estimate
+  uint64_t total_uj;
+  // sensor file descriptors
+  unsigned int count;
+  int fds[];
+} energymon_zcu102;
+
+static inline long get_update_interval(char** sensors, unsigned int num) {
+  unsigned long ret = 0;
+  unsigned long tmp;
+  unsigned int i;
+  char file[64];
+  int fd;
+  char cdata[24];
+  int read_ret;
+
+  for (i = 0; i < num; i++) {
+    snprintf(file, sizeof(file), INA226_FILE_TEMPLATE_UPDATE_PERIOD, sensors[i]);
+    if ((fd = open(file, O_RDONLY)) <= 0) {
+      perror(file);
+      continue;
+    }
+    // Read udpate time interval (values in milliseconds)
+    if ((read_ret = read(fd, cdata, sizeof(cdata))) <= 0) {
+      perror(file);
+    }
+#ifdef ENERGYMON_DEBUG
+      fprintf(stderr, "get_update_interval: Read value %s bytes from %s\n", cdata, file);
+#endif    
+    if (close(fd)) {
+      perror(file);
+    }
+    if (read_ret > 0) {
+      errno = 0;
+      tmp = strtoul(cdata, NULL, 0);
+      if (errno) {
+        perror(file);
+      } else {
+        // keep the largest update_interval
+        ret = tmp > ret ? tmp : ret;
+      }
+    }
+  }
+  ret = ret * 1000;  // Convert milliseconds to microseconds
+  if (!ret) {
+    ret = INA226_DEFAULT_UPDATE_INTERVAL_US;
+#ifdef ENERGYMON_DEBUG
+    fprintf(stderr, "get_update_interval: Using default value: %lu us\n", ret);
+#endif
+  }
+  return ret;
+}
+
+int energymon_finish_zcu102(energymon* em) {
+  if (em == NULL || em->state == NULL) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  int err_save = 0;
+  unsigned int i;
+  energymon_zcu102* state = (energymon_zcu102*) em->state;
+
+  if (state->poll_sensors) {
+    // stop sensors polling thread and cleanup
+    state->poll_sensors = 0;
+#ifndef __ANDROID__
+    pthread_cancel(state->thread);
+#endif
+    err_save = pthread_join(state->thread, NULL);
+  }
+
+  // close individual sensor files
+  for (i = 0; i < state->count; i++) {
+    if (state->fds[i] > 0 && close(state->fds[i])) {
+      err_save = err_save ? err_save : errno;
+    }
+  }
+  free(em->state);
+  em->state = NULL;
+  errno = err_save;
+  return errno ? -1 : 0;
+}
+
+/**
+ * Ignore non-directories and hidden/relative directories (. and ..).
+ * We expect the folder name to be something like 3-0040 or 4-0045.
+ */
+static inline int is_sensor_dir(struct dirent* entry) {
+  return (entry->d_type == DT_LNK || entry->d_type == DT_DIR)
+          && entry->d_name[0] != '.'
+          && entry->d_name[1] == '-';
+}
+
+static inline void free_sensor_directories(char** dirs, unsigned int n) {
+  while (n > 0) {
+    free(dirs[--n]);
+  }
+  free(dirs);
+}
+
+/**
+ * Set the count value to the number of sensors found.
+ * Returns a list of directories of size 'count', or NULL on failure.
+ */
+static inline char** get_sensor_directories(unsigned int* count) {
+  /*
+   * TODO: This implementation works for now but is brittle.  It assumes that
+   *   there are 18 sensors and that they are sequentially numbered from 0 to 17.
+   *   A better implementation would search the device directories to find all
+   *   the INA226's, just in case a future software update changes things.  The
+   *   odroid implementation does something like this but the sysfs directory
+   *   structure is different on the ZCU102 so the same exact code will not work.
+   *   If implementing this, it might be easier to use the alternate INA226_DIR
+   *   commented out above.
+   */
+  unsigned int i;
+  char** directories = NULL;
+  *count = 18;
+  errno = 0;
+
+  directories = calloc(*count, sizeof(char*));
+  if (directories != NULL) {
+    for (i = 0; i < *count; i++) {
+      directories[i] = calloc(1, sizeof(HWMON_DIR_EXAMPLE));
+      if (directories[i] == NULL) {
+	break; // calloc failed
+      }
+      snprintf(directories[i], sizeof(HWMON_DIR_EXAMPLE), "hwmon%d", i);
+    }
+  }
+  if (errno) { // from calloc
+    directories = NULL;
+    *count = 0;
+  }
+  return directories;
+}
+
+/**
+ * pthread function to poll the sensors at regular intervals.
+ */
+static void* zcu102_poll_sensors(void* args) {
+  energymon_zcu102* state = (energymon_zcu102*) args;
+  char cdata[10];
+  double sum_w;
+  unsigned long sum_uw;
+  unsigned int i;
+  uint64_t exec_us;
+  uint64_t last_us;
+  uint64_t delta_uj;
+  int err_save;
+  if (!(last_us = energymon_gettime_us())) {
+    // must be that CLOCK_MONOTONIC is not supported
+    perror("zcu102_poll_sensors");
+    return (void*) NULL;
+  }
+  energymon_sleep_us(state->read_delay_us, &state->poll_sensors);
+  while (state->poll_sensors) {
+    // read individual sensors (values in microWatts)
+    for (sum_uw = 0, errno = 0, i = 0; i < state->count && !errno; i++) {
+      if (pread(state->fds[i], cdata, sizeof(cdata), 0) > 0) {
+        sum_uw += strtoul(cdata, NULL, 0);
+      }
+    }
+    err_save = errno;
+    exec_us = energymon_gettime_elapsed_us(&last_us);
+    if (err_save) {
+      errno = err_save;
+      perror("zcu102_poll_sensors: skipping power sensor reading");
+    } else {
+      sum_w = sum_uw / 1e6;
+      delta_uj = sum_w * exec_us;
+#ifdef ENERGYMON_DEBUG
+      fprintf(stderr, "zcu102_poll_sensors: Read total power: %lu uW (%f W)\n", sum_uw, sum_w);
+      fprintf(stderr, "zcu102_poll_sensors: Calculated energy: %f W * %"PRIi64" us = %"PRIu64" uJ\n", sum_w, exec_us, delta_uj);
+#endif
+      state->total_uj += delta_uj;
+    }
+    // sleep for the update interval of the sensors (minus most overhead)
+    if (state->read_delay_us > exec_us) {
+      energymon_sleep_us(state->read_delay_us - exec_us, &state->poll_sensors);
+    }
+    errno = 0;
+  }
+  return (void*) NULL;
+}
+
+/**
+ * Open all sensor files and start the thread to poll the sensors.
+ */
+int energymon_init_zcu102(energymon* em) {
+  if (em == NULL || em->state != NULL) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  unsigned int i;
+  char file[64];
+  unsigned int count;
+
+  // find the sensors
+  char** sensor_dirs = get_sensor_directories(&count);
+  if (count == 0) {
+    perror("energymon_init_zcu102: Failed to find power sensors: "INA226_DIR);
+    return -1;
+  }
+
+  size_t size = sizeof(energymon_zcu102) + count * sizeof(int);
+  energymon_zcu102* state = calloc(1, size);
+  if (state == NULL) {
+    free_sensor_directories(sensor_dirs, count);
+    return -1;
+  }
+  state->count = count;
+
+  // open individual sensor files
+  em->state = state;
+  for (i = 0; i < state->count; i++) {
+    snprintf(file, sizeof(file), INA226_FILE_TEMPLATE_POWER, sensor_dirs[i]);
+#ifdef ENERGYMON_DEBUG
+    fprintf(stderr, "energymon_init_zcu102: Opening sensor file: %s\n", file);	
+#endif
+    state->fds[i] = open(file, O_RDONLY);
+    if (state->fds[i] < 0) {
+      perror(file);
+      free_sensor_directories(sensor_dirs, state->count);
+      energymon_finish_zcu102(em);
+      return -1;
+    }
+  }
+
+  // get the delay time between reads
+  state->read_delay_us = get_update_interval(sensor_dirs, state->count);
+
+  // we're finished with this variable
+  free_sensor_directories(sensor_dirs, state->count);
+
+  // start sensors polling thread
+  state->poll_sensors = 1;
+  errno = pthread_create(&state->thread, NULL, zcu102_poll_sensors, state);
+  if (errno) {
+    energymon_finish_zcu102(em);
+    return -1;
+  }
+
+  return 0;
+}
+
+uint64_t energymon_read_total_zcu102(const energymon* em) {
+  if (em == NULL || em->state == NULL) {
+    errno = EINVAL;
+    return 0;
+  }
+  return ((energymon_zcu102*) em->state)->total_uj;
+}
+
+char* energymon_get_source_zcu102(char* buffer, size_t n) {
+  return energymon_strencpy(buffer, "ZCU102 INA226 Power Sensors", n);
+}
+
+uint64_t energymon_get_interval_zcu102(const energymon* em) {
+  if (em == NULL || em->state == NULL) {
+    errno = EINVAL;
+    return 0;
+  }
+  return ((energymon_zcu102*) em->state)->read_delay_us;
+}
+
+uint64_t energymon_get_precision_zcu102(const energymon* em) {
+  if (em == NULL || em->state == NULL) {
+    errno = EINVAL;
+    return 0;
+  }
+  // On the ZCU102, the sensors change in increments of 25 mW so the
+  //   minimum energy delta = 25 mW * the update interval time.
+  uint64_t prec = 0.025 * energymon_get_interval_zcu102(em);
+  return prec ? prec : 1;
+}
+
+int energymon_is_exclusive_zcu102(void) {
+  return 0;
+}
+
+int energymon_get_zcu102(energymon* em) {
+  if (em == NULL) {
+    errno = EINVAL;
+    return -1;
+  }
+  em->finit = &energymon_init_zcu102;
+  em->fread = &energymon_read_total_zcu102;
+  em->ffinish = &energymon_finish_zcu102;
+  em->fsource = &energymon_get_source_zcu102;
+  em->finterval = &energymon_get_interval_zcu102;
+  em->fprecision = &energymon_get_precision_zcu102;
+  em->fexclusive = &energymon_is_exclusive_zcu102;
+  em->state = NULL;
+  return 0;
+}

--- a/zcu102/energymon-zcu102.h
+++ b/zcu102/energymon-zcu102.h
@@ -1,0 +1,38 @@
+/**
+ * Energy reading for a ZCU102 with INA226 power sensors.
+ *
+ * @author Jason Miller
+ * @date 2017-02-14
+ */
+#ifndef _ENERGYMON_ZCU102_H_
+#define _ENERGYMON_ZCU102_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <inttypes.h>
+#include <stddef.h>
+#include "energymon.h"
+
+int energymon_init_zcu102(energymon* em);
+
+uint64_t energymon_read_total_zcu102(const energymon* em);
+
+int energymon_finish_zcu102(energymon* em);
+
+char* energymon_get_source_zcu102(char* buffer, size_t n);
+
+uint64_t energymon_get_interval_zcu102(const energymon* em);
+
+uint64_t energymon_get_precision_zcu102(const energymon* em);
+
+int energymon_is_exclusive_zcu102(void);
+
+int energymon_get_zcu102(energymon* em);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
This is an initial implementation for the Xilinx ZCU102 evaluation board.  It is based on the odroid sysfs implementation but there are several differences:
1. The sensors on the ZCU102 are always enabled so I removed all code relating to enabling sensors,
2. The update interval is reported in milliseconds instead of microseconds, so I converted,
3. Power numbers are reported in microwatts instead of watts, so I converted,
4. The precision calculation is different,
5. And most importantly, the sysfs directory structure and files are a bit different so the templates and sensor discovery have changed (more on this below).

The sysfs directory structure on the ZCU102 makes it a little trickier to find and access all the sensor files.  The interface files are not directly in the sensor directory within `/sys/bus/i2c/drivers/ina2xx` as they are on the odroid.  Instead they are a couple subdirs down and one subdir name is different for each sensor.  For now, it was easier for me to access the sensors through `/sys/class/hwmon` where the sensors are sequentially numbered and I can hardcode the directory names.  This is a little brittle but since this implementation is for one specific board, I think it's fairly safe.  I have included a comment in `get_sensor_directories` mentioning this in case someone wants to create a more robust version in the future.